### PR TITLE
Minor build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ MANDIR=		$(TOPDIR)/man
 # Library functions are put in an archive in LIBDIR.
 
 LIBDIR=		$(TOPDIR)/lib
-TZLIB=		$(LIBDIR)/libtz.a
 
 # If you always want time values interpreted as "seconds since the epoch
 # (not counting leap seconds)", use
@@ -341,21 +340,23 @@ ENCHILADA=	$(COMMON) $(DOCS) $(SOURCES) $(DATA) $(MISC)
 
 SHELL=		/bin/sh
 
-all:		tzselect zic zdump $(LIBOBJS) $(TABDATA)
+all:		tzselect zic zdump libtz.a $(TABDATA)
 
 ALL:		all date
 
-install:	all $(DATA) $(REDO) $(DESTDIR)$(TZLIB) $(MANS)
+install:	all $(DATA) $(REDO) $(MANS)
 		$(ZIC) -y $(YEARISTYPE) \
 			-d $(DESTDIR)$(TZDIR) -l $(LOCALTIME) -p $(POSIXRULES)
 		-rm -f $(DESTDIR)$(TZDIR)/iso3166.tab \
 			$(DESTDIR)$(TZDIR)/zone.tab
 		cp iso3166.tab zone.tab $(DESTDIR)$(TZDIR)/.
-		-mkdir $(DESTDIR)$(TOPDIR) $(DESTDIR)$(ETCDIR)
+		mkdir -p $(DESTDIR)$(TOPDIR)
+		mkdir -p $(DESTDIR)$(ETCDIR)
 		cp tzselect zic zdump $(DESTDIR)$(ETCDIR)/.
-		-mkdir $(DESTDIR)$(TOPDIR) $(DESTDIR)$(MANDIR) \
-			$(DESTDIR)$(MANDIR)/man3 $(DESTDIR)$(MANDIR)/man5 \
-			$(DESTDIR)$(MANDIR)/man8
+		mkdir -p $(DESTDIR)$(LIBDIR)
+		cp libtz.a $(DESTDIR)$(LIBDIR)/.
+		mkdir -p $(DESTDIR)$(MANDIR) $(DESTDIR)$(MANDIR)/man3 \
+			$(DESTDIR)$(MANDIR)/man5 $(DESTDIR)$(MANDIR)/man8
 		-rm -f $(DESTDIR)$(MANDIR)/man3/newctime.3 \
 			$(DESTDIR)$(MANDIR)/man3/newtzset.3 \
 			$(DESTDIR)$(MANDIR)/man5/tzfile.5 \
@@ -427,8 +428,7 @@ posix_right:	posix_only leapseconds
 
 zones:		$(REDO)
 
-$(DESTDIR)$(TZLIB): $(LIBOBJS)
-		-mkdir -p $(DESTDIR)$(TOPDIR) $(DESTDIR)$(LIBDIR)
+libtz.a:	$(LIBOBJS)
 		$(AR) ru $@ $(LIBOBJS)
 		if [ -x /usr/ucb/ranlib ] || [ -x /usr/bin/ranlib ]; \
 			then ranlib $@ ; fi


### PR DESCRIPTION
The first commit allows the user to pass in AR in order to override the ar used to create libtz.a.

The second commit moves building of libtz.a to the all target, and copies it over to DESTDIR in the install target.
