### PR TITLE
Correct DST in Asia/Taipei

### DIFF
--- a/asia
+++ b/asia
@@ -678,9 +678,35 @@ Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 30
 # As per Yu-Cheng Chuang, say that Taiwan was at UT+9 from 1937-10-01
 # until 1945-10-25, overriding Shanks & Pottenger.
 
+# From Yu-Cheng Chuang (2014-07-02):
+# In 1946, DST in Taiwan was from May 15 and ended on Sep 30. The info from
+# Central Weather Bureau website was not correct.
+#
+# Original Bulletin:
+# <http://subtpg.tpg.gov.tw/og/image2.asp?f=03502F0AKM1AF>
+# <http://subtpg.tpg.gov.tw/og/image2.asp?f=0350300AKM1B0> (cont.)
+#
+# In 1947, DST in Taiwan was expanded to Oct 31. There is a backup of that
+# telegram announcement from Taiwan Province Government:
+#
+# <http://subtpg.tpg.gov.tw/og/image2.asp?f=0360310AKZ431>
+#
+# Here is a brief translation:
+#
+#   The Summer Time this year is adopted from midnight Apr 15 until Sep 20
+#   midnight. To save (energy?) consumption, we're expanding Summer Time
+#   adption till Oct 31 midnight.
+#
+# The Central Weather Bureau website didn't mention that, however it can
+# be found from historical government announcement database.
+ 
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Taiwan	1946	1951	-	May	1	0:00	1:00	D
-Rule	Taiwan	1946	1951	-	Oct	1	0:00	0	S
+Rule	Taiwan	1946	only	-	May	15	0:00	1:00	D
+Rule	Taiwan	1946	only	-	Oct	1	0:00	0	S
+Rule	Taiwan	1947	only	-	Apr	15	0:00	1:00	D
+Rule	Taiwan	1947	only	-	Nov	1	0:00	0	S
+Rule	Taiwan	1948	1951	-	May	1	0:00	1:00	D
+Rule	Taiwan	1948	1951	-	Oct	1	0:00	0	S
 Rule	Taiwan	1952	only	-	Mar	1	0:00	1:00	D
 Rule	Taiwan	1952	1954	-	Nov	1	0:00	0	S
 Rule	Taiwan	1953	1959	-	Apr	1	0:00	1:00	D
@@ -688,8 +714,8 @@ Rule	Taiwan	1955	1961	-	Oct	1	0:00	0	S
 Rule	Taiwan	1960	1961	-	Jun	1	0:00	1:00	D
 Rule	Taiwan	1974	1975	-	Apr	1	0:00	1:00	D
 Rule	Taiwan	1974	1975	-	Oct	1	0:00	0	S
-Rule	Taiwan	1979	only	-	Jun	30	0:00	1:00	D
-Rule	Taiwan	1979	only	-	Sep	30	0:00	0	S
+Rule	Taiwan	1979	only	-	Jul	1	0:00	1:00	D
+Rule	Taiwan	1979	only	-	Oct	1	0:00	0	S
 
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 # Taipei or Taibei or T'ai-pei


### PR DESCRIPTION
Hi,

I'm Yu-Cheng Chuang who talked about some time zone things in Taiwan during WW2 on the mailing list.

I've read through all the government announcements about DST from official websites [1] [2] and found that the most-cited CWB (Central Weather Bureau) page didn't have the most correct info.

In 1946, DST in Taiwan was adopted from May 15, not May 1, according to the announcement [3].

In 1947, DST in Taiwan was expanded to Oct 31. It were originally planned to be from Apr 15 until Sep 20, however it was expanded to Oct 31 for "saving (energy?) consumption" [4]. So it was not adopted form May 1, but from Apr 15. Also, it was expanded until Oct 31, not Sep 30 as originally planned.

In addition, I've also corrected the DST in 1979, which was adopted from Jul 1 until Sep 30. This part is correct in CWB's webpage, so I believe it was just a typo. I fixed it.

<del>However, it is weird that I cannot found any announcement about DST in 1946. Taiwan was returned to Republic of China so there should be an announcement, just like each other years. I'll ask for the National Library about it.</del> Update: found it. See above.

Here is all the info I can found from the historical announcement system:

| ROC | Year | start | end | go back |
| --- | --- | --- | --- | --- |
| 35 | 1946 | 5/15 | 9/30 | 10/1 |
| 36 | 1947 | 4/15 | 10/31 | 11/1 |
| 37 | 1948 | 5/1 | 9/30 | 10/1 |
| 38 | 1949 | 5/1 | 9/30 | 10/1 |
| 39 | 1950 | 5/1 | 9/30 | 10/1 |
| 40 | 1951 | 5/1 | 9/30 | 10/1 |
| 41 | 1952 | 3/1 | 10/31 | 11/1 |
| 42 | 1953 | 4/1 | 10/31 | 11/1 |
| 43 | 1954 | 4/1 | 10/31 | 11/1 |
| 44 | 1955 | 4/1 | 9/30 | 10/1 |
| 45 | 1956 | 4/1 | 9/30 | 10/1 |
| 46 | 1957 | 4/1 | 9/30 | 10/1 |
| 47 | 1958 | 4/1 | 9/30 | 10/1 |
| 48 | 1959 | 4/1 | 9/30 | 10/1 |
| 49 | 1960 | 6/1 | 9/30 | 10/1 |
| 50 | 1961 | 6/1 | 9/30 | 10/1 |
| 51 | 1962 | - | - | - |
| 52 | 1963 | - | - | - |
| 53 | 1964 | - | - | - |
| 54 | 1965 | - | - | - |
| 55 | 1966 | - | - | - |
| 56 | 1967 | - | - | - |
| 57 | 1968 | - | - | - |
| 58 | 1969 | - | - | - |
| 59 | 1970 | - | - | - |
| 60 | 1971 | - | - | - |
| 61 | 1972 | - | - | - |
| 62 | 1973 | - | - | - |
| 63 | 1974 | 4/1 | 9/30 | 10/1 |
| 64 | 1975 | 4/1 | 9/30 | 10/1 |
| 65 | 1976 | - | - | - |
| 66 | 1977 | - | - | - |
| 67 | 1978 | - | - | - |
| 68 | 1979 | 7/1 | 9/30 | 10/1 |

I hope I got the correct format of TZ database. If anything is wrong, feel free to correct.

Thanks!

[1]: Taiwan Province Government Bulletin Search System: http://subtpg.tpg.gov.tw/og/q1.asp

[2]: National Central Library Gazette Online: http://gaz.ncl.edu.tw/

[3]: The bulletin on May 16, 1946: http://subtpg.tpg.gov.tw/og/image2.asp?f=03502F0AKM1AF and http://subtpg.tpg.gov.tw/og/image2.asp?f=0350300AKM1B0

[4]: The bulletin on Sep 15, 1947: http://subtpg.tpg.gov.tw/og/image2.asp?f=0360310AKZ431

---

**Update**: I've just found the DST bulletin in 1946, and I'm sure that DST in 1946 was from May 15, not May 1.
