### PR TITLE
Correct DST in Asia/Seoul

### DIFF
--- a/asia
+++ b/asia
@@ -1669,12 +1669,24 @@ Zone	Asia/Bishkek	4:58:24 -	LMT	1924 May  2
 # the system may begin as early as 2008....  Korea ran a daylight
 # saving program from 1949-61 but stopped it during the 1950-53 Korean War.
 
-# From Shanks & Pottenger:
+# From Sanghyuk Jung (2014-10-30):
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	ROK	1960	only	-	May	15	0:00	1:00	D
-Rule	ROK	1960	only	-	Sep	13	0:00	0	S
-Rule	ROK	1987	1988	-	May	Sun>=8	0:00	1:00	D
-Rule	ROK	1987	1988	-	Oct	Sun>=8	0:00	0	S
+Rule	ROK	1948	only	-	June	1	0:00	1:00	D
+Rule	ROK	1948	only	-	Sep	13	0:00	0	S
+Rule	ROK	1949	only	-	Apr	3	0:00	1:00	D
+Rule	ROK	1949	only	-	Sep	11	0:00	0	S
+Rule	ROK	1950	only	-	Apr	1	0:00	1:00	D
+Rule	ROK	1950	only	-	Sep	10	0:00	0	S
+Rule	ROK	1951	only	-	May	6	0:00	1:00	D
+Rule	ROK	1951	only	-	Sep	9	0:00	0	S
+Rule	ROK	1955	only	-	May	5	0:00	1:00	D
+Rule	ROK	1955	only	-	Sep	9	0:00	0	S
+Rule	ROK	1956	only	-	May	20	0:00	1:00	D
+Rule	ROK	1956	only	-	Sep	30	0:00	0	S
+Rule	ROK	1957	1960	-	May	Sun>=1	0:00	1:00	D
+Rule	ROK	1957	1960	-	Sep	Sun>=20	0:00	0	S
+Rule	ROK	1987	1988	-	May	Sun>=8	2:00	1:00	D
+Rule	ROK	1987	1988	-	Oct	Sun>=8	3:00	0	S
 
 # From Paul Eggert (2014-07-01):
 # The following entries are from Shanks & Pottenger, except that I


### PR DESCRIPTION
Hello,

According  to the Korean Wikipedia ( http://ko.wikipedia.org/wiki/%ED%95%9C%EA%B5%AD_%ED%91%9C%EC%A4%80%EC%8B%9C) , DST in Republic of Korean was as  follows.
- 1948.06.01. 00:00 ~ 1948.09.13. 00:00
- 1949.04.03. 00:00 ~ 1949.09.11. 00:00
- 1950.04.01. 00:00 ~ 1950.09.10. 00:00
- 1951.05.06. 00:00 ~ 1951.09.09. 00:00
- 1955.05.05. 00:00 ~ 1955.09.09. 00:00
- 1956.05.20. 00:00 ~ 1956.09.30. 00:00
- 1957.05.05. 00:00 ~ 1957.09.22. 00:00
- 1958.05.04. 00:00 ~ 1958.09.21. 00:00
- 1959.05.03. 00:00 ~ 1959.09.20. 00:00
- 1960.05.01. 00:00 ~ 1960.09.18. 00:00
- 1987.05.10. 02:00 ~ 1987.10.11. 03:00
- 1988.05.08. 02:00 ~ 1988.10.09. 03:00

It almostly corresponds with  the exsiting comments in 'asia' file.

```
# From Annie I. Bang (2006-07-10):
# http://www.koreaherald.co.kr/SITE/data/html_dir/2006/07/10/200607100012.asp
# The Ministry of Commerce, Industry and Energy has already
# commissioned a research project [to reintroduce DST] and has said
# the system may begin as early as 2008....  Korea ran a daylight
# saving program from 1949-61 but stopped it during the 1950-53 Korean War.
```

And I checked old newspapers in Korean,  all articles correspond with data in Wikipedia.
For example, [the article in 1948](http://newslibrary.naver.com/viewer/index.nhn?articleId=1948060100209202008&editNo=1&printCount=1&publishDate=1948-06-01&officeId=00020&pageNo=2&printNo=7607&publishType=00020)(Korean Language) proved that DST started at June 1 in that year.
For another example, [the article in 1988](http://newslibrary.naver.com/viewer/index.nhn?articleId=1988050700099215012&editNo=1&printCount=1&publishDate=1988-05-07&officeId=00009&pageNo=15&printNo=6822&publishType=00020)  said that  DST started at 2:00 AM in that year.

I tried to find simple rules to define DST, like 'SUN=>1', but cannot make it except 1957-1960.
