### PR TITLE
tzselect: Fix for gawk treating '\.' as plain '.'

### DIFF
--- a/tzselect.ksh
+++ b/tzselect.ksh
@@ -328,7 +328,7 @@ while
 				tzname = "[^-+,0-9][^-+,0-9][^-+,0-9]+"
 				time = "[0-2]?[0-9](:[0-5][0-9](:[0-5][0-9])?)?"
 				offset = "[-+]?" time
-				date = "(J?[0-9]+|M[0-9]+\.[0-9]+\.[0-9]+)"
+				date = "(J?[0-9]+|M[0-9]+\\.[0-9]+\\.[0-9]+)"
 				datetime = "," date "(/" time ")?"
 				tzpattern = "^(:.*|" tzname offset "(" tzname \
 				  "(" offset ")?(" datetime datetime ")?)?)$"


### PR DESCRIPTION
When using gawk and Posix TZ in tzselect, this warning is shown:
    awk: cmd. line:1: warning: escape sequence `\.' treated as plain`.'
gawk treats '.' as '.'
mawk treats '.' as '.'
both treat '\.' as '\.'
The 2nd and 3rd are corrrect for 'Mm.w.d'.

Test:
gawk 'BEGIN{ date = "."; print date }'
gawk 'BEGIN{ date = "\."; print date }'
versus:
mawk 'BEGIN{ date = "."; print date }'
mawk 'BEGIN{ date = "\."; print date }'
