### PR TITLE
tzselect: Removed spaces in calls to awk-functions

### DIFF
--- a/tzselect.ksh
+++ b/tzselect.ksh
@@ -228,10 +228,10 @@ output_distances='
   # case of the Vicenty formula for distances on ellipsoids.
   function gcdist(lat1, long1, lat2, long2, dlong, x, y, num, denom) {
     dlong = long2 - long1
-    x = cos (lat2) * sin (dlong)
-    y = cos (lat1) * sin (lat2) - sin (lat1) * cos (lat2) * cos (dlong)
-    num = sqrt (x * x + y * y)
-    denom = sin (lat1) * sin (lat2) + cos (lat1) * cos (lat2) * cos (dlong)
+    x = cos(lat2) * sin(dlong)
+    y = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dlong)
+    num = sqrt(x * x + y * y)
+    denom = sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(dlong)
     return atan2(num, denom)
   }
   # Parallel distance between points with given latitude and longitude.
@@ -240,12 +240,12 @@ output_distances='
   # I.e., it considers longitudes to be further apart if they are
   # nearer the equator.
   function pardist(lat1, long1, lat2, long2) {
-    return abs (long1 - long2) * min (cos (lat1), cos (lat2))
+    return abs(long1 - long2) * min(cos(lat1), cos(lat2))
   }
   # The distance function is the sum of the great-circle distance and
   # the parallel distance.  It could be weighted.
   function dist(lat1, long1, lat2, long2) {
-    return gcdist (lat1, long1, lat2, long2) + pardist (lat1, long1, lat2, long2)
+    return gcdist(lat1, long1, lat2, long2) + pardist(lat1, long1, lat2, long2)
   }
   BEGIN {
     coord_lat = convert_latitude(coord)


### PR DESCRIPTION
Explanation:
GNU awk fails when a user-defined-functions is called with a space like in
'myUDF ()'. It does not fail when calling builtin functions, but removed
those spaces too.

Example code:
good_awk='function echo(x) { return x; } BEGIN { print echo("x"); }'
bad_awk_='function echo(x) { return x; } BEGIN { print echo ("x"); }'
sin_awk='BEGIN { print sin (0) }'

mawk -W version 2>/dev/null | head -n1
mawk "${sin_awk}"
mawk "${good_awk}"
mawk "${bad_awk_}"
gawk -V | head -n1
gawk "${sin_awk}"
gawk "${good_awk}"
gawk "${bad_awk_}"

Output:
mawk 1.3.4 20141027
0
x
x
GNU Awk 4.0.2
0
x
gawk: cmd. line:1: error: function `echo' called with space between name
and`(',
