### PR TITLE
Correct country short name for GB to "United Kingdom"

### DIFF
--- a/iso3166.tab
+++ b/iso3166.tab
@@ -99,7 +99,7 @@ FM	Micronesia
 FO	Faroe Islands
 FR	France
 GA	Gabon
-GB	Britain (UK)
+GB	United Kingdom
 GD	Grenada
 GE	Georgia
 GF	French Guiana


### PR DESCRIPTION
Reference: ISO 3166-1 Newsletter No. V-11 2006-03-29
http://mm.icann.org/pipermail/tz/2017-February/024873.html