### PR TITLE
Update Hong Kong section name

### DIFF
--- a/asia
+++ b/asia
@@ -572,7 +572,7 @@ Zone	Asia/Urumqi	5:50:20	-	LMT	1928
 			6:00	-	+06
 
 
-# Hong Kong (Xianggang)
+# Hong Kong
 
 # Milne gives 7:36:41.7; round this.
 


### PR DESCRIPTION
No one ever calls Hong Kong as Xianggang, in the past or currently. At one time Hong Kong was labeled as such years ago on Google Maps, which was likely the result of automatic romanization of Mandarin. The Pinyin romanization scheme of the Mandarin pronunciation of 香港 is not officially recognized or even mentioned in official documents.

https://www.basiclaw.gov.hk/en/basiclawtext/chapter_1.html

https://www.elegislation.gov.hk/hk/cap5