### PR TITLE
Update Ukrainian Timezones Names

### DIFF
--- a/zone1970.tab
+++ b/zone1970.tab
@@ -290,7 +290,7 @@ RS,BA,HR,ME,MK,SI	+4450+02030	Europe/Belgrade
 RU	+5443+02030	Europe/Kaliningrad	MSK-01 - Kaliningrad
 RU	+554521+0373704	Europe/Moscow	MSK+00 - Moscow area
 # Mention RU and UA alphabetically.  See "territorial claims" above.
-RU,UA	+4457+03406	Europe/Simferopol	MSK+00 - Crimea
+RU,UA	+4457+03406	Europe/Simferopol
 RU	+5836+04939	Europe/Kirov	MSK+00 - Kirov
 RU	+4621+04803	Europe/Astrakhan	MSK+01 - Astrakhan
 RU	+4844+04425	Europe/Volgograd	MSK+01 - Volgograd
@@ -340,9 +340,9 @@ TR	+4101+02858	Europe/Istanbul
 TT,AG,AI,BL,DM,GD,GP,KN,LC,MF,MS,VC,VG,VI	+1039-06131	America/Port_of_Spain
 TV	-0831+17913	Pacific/Funafuti
 TW	+2503+12130	Asia/Taipei
-UA	+5026+03031	Europe/Kiev	Ukraine (most areas)
-UA	+4837+02218	Europe/Uzhgorod	Ruthenia
-UA	+4750+03510	Europe/Zaporozhye	Zaporozh'ye/Zaporizhia; Lugansk/Luhansk (east)
+UA	+5026+03031	Europe/Kiev
+UA	+4837+02218	Europe/Uzhgorod
+UA	+4750+03510	Europe/Zaporozhye
 UM	+1917+16637	Pacific/Wake	Wake Island
 US	+404251-0740023	America/New_York	Eastern (most areas)
 US	+421953-0830245	America/Detroit	Eastern - MI (most areas)


### PR DESCRIPTION
Default timezone names for Ukraine, _e.g. Europe/Kiev_, a more understandable and correct than ridiculous fantasy style, _e.g. Ruthenia_. Previous names cause confusion, misunderstanding and are considered inappropriate.

Proofs: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198822, https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=47468, https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244644.

