### PR TITLE
Change Europe/Kiev to Europe/Kyiv to use correct spelling

### DIFF
--- a/europe
+++ b/europe
@@ -4049,23 +4049,10 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # * Ukrainian Government's Resolution of 20.03.1992, No. 139.
 # http://www.uazakon.com/documents/date_8u/pg_grcasa.htm
 
-# From Paul Eggert (2018-10-03):
-# As is usual in tzdb, Ukrainian zones use the most common English spellings.
-# For example, tzdb uses Europe/Kiev, as "Kiev" is the most common spelling in
-# English for Ukraine's capital, even though it is certainly wrong as a
-# transliteration of the Ukrainian "Київ".  This is similar to tzdb's use of
-# Europe/Prague, which is certainly wrong as a transliteration of the Czech
-# "Praha".  ("Kiev" came from old Slavic via Russian to English, and "Prague"
-# came from old Slavic via French to English, so the two cases have something
-# in common.)  Admittedly English-language spelling of Ukrainian names is
-# controversial, and some day "Kyiv" may become substantially more popular in
-# English; in the meantime, stick with the traditional English "Kiev" as that
-# means less disruption for our users.
-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-# This represents most of Ukraine.  See above for the spelling of "Kiev".
-Zone Europe/Kiev	2:02:04 -	LMT	1880
-			2:02:04	-	KMT	1924 May  2 # Kiev Mean Time
+# This represents most of Ukraine.
+Zone Europe/Kyiv	2:02:04 -	LMT	1880
+			2:02:04	-	KMT	1924 May  2 # Kyiv Mean Time
 			2:00	-	EET	1930 Jun 21
 			3:00	-	MSK	1941 Sep 20
 			1:00	C-Eur	CE%sT	1943 Nov  6

--- a/theory.html
+++ b/theory.html
@@ -485,7 +485,7 @@ in decreasing order of importance:
       HMT Havana, Helsinki, Horta, Howrah;
       IMT Irkutsk, Istanbul;
       JMT Jerusalem;
-      KMT Kaunas, Kiev, Kingston;
+      KMT Kaunas, Kyiv, Kingston;
       LMT Lima, Lisbon, local, Luanda;
       MMT Macassar, Madras, Malé, Managua, Minsk, Monrovia, Montevideo,
 	Moratuwa, Moscow;

--- a/zone.tab
+++ b/zone.tab
@@ -398,7 +398,7 @@ TT	+1039-06131	America/Port_of_Spain
 TV	-0831+17913	Pacific/Funafuti
 TW	+2503+12130	Asia/Taipei
 TZ	-0648+03917	Africa/Dar_es_Salaam
-UA	+5026+03031	Europe/Kiev	Ukraine (most areas)
+UA	+5026+03031	Europe/Kyiv	Ukraine (most areas)
 UA	+4837+02218	Europe/Uzhgorod	Transcarpathia
 UA	+4750+03510	Europe/Zaporozhye	Zaporozhye and east Lugansk
 UG	+0019+03225	Africa/Kampala

--- a/zone1970.tab
+++ b/zone1970.tab
@@ -340,7 +340,7 @@ TR	+4101+02858	Europe/Istanbul
 TT,AG,AI,BL,DM,GD,GP,KN,LC,MF,MS,VC,VG,VI	+1039-06131	America/Port_of_Spain
 TV	-0831+17913	Pacific/Funafuti
 TW	+2503+12130	Asia/Taipei
-UA	+5026+03031	Europe/Kiev	Ukraine (most areas)
+UA	+5026+03031	Europe/Kyiv	Ukraine (most areas)
 UA	+4837+02218	Europe/Uzhgorod	Transcarpathia
 UA	+4750+03510	Europe/Zaporozhye	Zaporozhye and east Lugansk
 UM	+1917+16637	Pacific/Wake	Wake Island


### PR DESCRIPTION
Disclaimer: Language question is tough for Ukraine, and I have no
            intention to speculate on the topic. The PR is about
            concrete renaming Kiev to Kyiv according to national
            and worldwide version of spelling of the capital of
            Ukraine.

I would agree with comment of @eggert, that transliteration of "Київ"
to Kiev is wrong and for some reasons was popular.
However, I do believe we should use the real city name instead
of what was "popular" to avoid any further confusion. Popularity
is a volatile thing, and can't be used in systems which supposed to
be consistent. That will generate a lot of whys and can lead to
misunderstanding.

Described example about Praha and Prague doesn't make much sense.
I think governments of both countries highlight that. The
Government of the Czech Republic uses "Prague" (1) when
the Cabinet of Ministers of Ukraine uses "Kyiv" (2). What I'm
trying to say, is that even if Prague is written incorrectly,
it accepted by society.
Nowadays, the majority of map services, such as google/maps,
openstreetmap, mapbox use Kyiv as well when you search for
the capital of Ukraine.

Moreover, "Kyiv" is used by other governments and press (3,4,5,6).
Not all of them, of course, but I think that may change anytime
soon.

Links:
1. https://www.vlada.cz/en/urad-vlady/adresa-uradu-vlady/contact-address-50831/
2. https://www.kmu.gov.ua/en/kontakti
3. https://www.ft.com/stream/8e326860-810f-3f96-8b08-8db10ef58906
4. https://www.nytimes.com/search?query=kyiv
5. https://www.gov.uk/world/organisations/british-embassy-kyiv
6. https://www.rferl.org/a/us-to-change-international-database-spelling-to-kyiv-not-kiev/29997415.html