### PR TITLE
KyivNotKiev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ version.h
 yearistype
 zdump
 zic
+
+.idea/

--- a/europe
+++ b/europe
@@ -4092,8 +4092,8 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # This represents most of Ukraine.  See above for the spelling of "Kiev".
-Zone Europe/Kiev	2:02:04 -	LMT	1880
-			2:02:04	-	KMT	1924 May  2 # Kiev Mean Time
+Zone Europe/Kyiv	2:02:04 -	LMT	1880
+			2:02:04	-	KMT	1924 May  2 # Kyiv Mean Time
 			2:00	-	EET	1930 Jun 21
 			3:00	-	MSK	1941 Sep 20
 			1:00	C-Eur	CE%sT	1943 Nov  6

--- a/theory.html
+++ b/theory.html
@@ -487,7 +487,7 @@ in decreasing order of importance:
       HMT Havana, Helsinki, Horta, Howrah;
       IMT Irkutsk, Istanbul;
       JMT Jerusalem;
-      KMT Kaunas, Kiev, Kingston;
+      KMT Kaunas, Kyiv, Kingston;
       LMT Lima, Lisbon, local, Luanda;
       MMT Macassar, Madras, Malé, Managua, Minsk, Monrovia, Montevideo,
 	Moratuwa, Moscow;

--- a/zone.tab
+++ b/zone.tab
@@ -400,7 +400,7 @@ TT	+1039-06131	America/Port_of_Spain
 TV	-0831+17913	Pacific/Funafuti
 TW	+2503+12130	Asia/Taipei
 TZ	-0648+03917	Africa/Dar_es_Salaam
-UA	+5026+03031	Europe/Kiev	Ukraine (most areas)
+UA	+5026+03031	Europe/Kyiv	Ukraine (most areas)
 UA	+4837+02218	Europe/Uzhgorod	Transcarpathia
 UA	+4750+03510	Europe/Zaporozhye	Zaporozhye and east Lugansk
 UG	+0019+03225	Africa/Kampala

--- a/zone1970.tab
+++ b/zone1970.tab
@@ -330,7 +330,7 @@ TO	-210800-1751200	Pacific/Tongatapu
 TR	+4101+02858	Europe/Istanbul
 TV	-0831+17913	Pacific/Funafuti
 TW	+2503+12130	Asia/Taipei
-UA	+5026+03031	Europe/Kiev	Ukraine (most areas)
+UA	+5026+03031	Europe/Kyiv	Ukraine (most areas)
 UA	+4837+02218	Europe/Uzhgorod	Transcarpathia
 UA	+4750+03510	Europe/Zaporozhye	Zaporozhye and east Lugansk
 UM	+1917+16637	Pacific/Wake	Wake Island


### PR DESCRIPTION
In September 2020, the English Wikipedia switched from using Kiev to Kyiv.

https://en.wikipedia.org/wiki/KyivNotKiev