### PR TITLE
fix buffer size calculation for envvar

### DIFF
--- a/zic.c
+++ b/zic.c
@@ -3421,7 +3421,9 @@ outzone(const struct zone *zpfirst, ptrdiff_t zonecount)
 
 	/* This cannot overflow; see FORMAT_LEN_GROWTH_BOUND.  */
 	max_abbr_len = 2 + max_format_len + max_abbrvar_len;
-	max_envvar_len = 2 * max_abbr_len + 5 * 9;
+	/* Extra space for: 2 stringoffset outputs (10 chars each), 2 stringrule
+	   outputs (18 chars each), and 2 commas: 2*10 + 2*18 + 2 = 58.  */
+	max_envvar_len = 2 * max_abbr_len + 58;
 
 	startbuf = xmalloc(max_abbr_len + 1);
 	ab = xmalloc(max_abbr_len + 1);


### PR DESCRIPTION
The buffer size used for building the POSIX TZ environment string
in outzone() is currently underestimated.

The existing formula assumes a fixed upper bound for all
non-abbreviation components, but it does not account for the
maximum output of stringoffset() and stringrule(). In particular,
stringoffset() can produce up to 10 characters (e.g. "-167:59:59")
and stringrule() can produce up to 18 characters depending on
the rule format.

This can lead to writing beyond the allocated buffer when
processing certain timezone inputs.

This change updates the calculation of max_envvar_len to
correctly account for these cases and ensure sufficient space
is allocated.