### PR TITLE
fuzz: add libFuzzer harness for TZif binary format parser

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,46 @@
+# tz Fuzz Harnesses
+
+Coverage-guided fuzz harnesses for the tz (tzdata) TZif binary format parser.
+
+## Harnesses
+
+### `fuzz_tzif.c`
+
+Targets `tzloadbody()` in `localtime.c` — the parser for TZif version 1/2/3
+binary timezone data files.
+
+**Why this matters:**
+
+Any process that calls `tzset(3)` with a TZ environment variable pointing to
+a file (e.g. `TZ=:/path/to/file`) will call `tzloadbody()` on that file's
+contents. This is exploitable when:
+- An attacker can write a file that ends up in TZ (e.g. via container mounts)
+- An application calls `tzalloc()` with user-controlled input
+- A crafted `/usr/share/zoneinfo/` entry is installed
+
+Bugs in `detzcode()`/`detzcode64()` result handling, array bounds checks on
+`ttis[]`, `leaps[]`, `chars[]`, or version-2/3 header parsing could cause
+out-of-bounds reads in privileged processes.
+
+## Building
+
+```bash
+clang -fsanitize=fuzzer,address \
+      fuzz/fuzz_tzif.c localtime.c asctime.c difftime.c strftime.c \
+      -o fuzz_tzif
+
+./fuzz_tzif -max_total_time=60
+```
+
+## Seed Corpus
+
+Use real TZif files from `/usr/share/zoneinfo/` as a starting corpus:
+
+```bash
+mkdir corpus/
+cp /usr/share/zoneinfo/America/New_York corpus/
+cp /usr/share/zoneinfo/Europe/London corpus/
+cp /usr/share/zoneinfo/Asia/Tokyo corpus/
+cp /usr/share/zoneinfo/UTC corpus/
+./fuzz_tzif corpus/ -max_total_time=300
+```

--- a/fuzz/fuzz_tzif.c
+++ b/fuzz/fuzz_tzif.c
@@ -1,0 +1,79 @@
+/*
+ * Fuzz harness for the tz (tzdata) TZif binary format parser.
+ *
+ * Target: tzloadbody() in localtime.c, which parses TZif version 1/2/3
+ * binary timezone data files.
+ *
+ * Attack surface:
+ *   - Any process calling tzset(3) with a crafted TZ environment variable
+ *     pointing to an attacker-controlled file (e.g. "TZ=:./evil.tzif")
+ *   - Container environments sharing a mounted /usr/share/zoneinfo
+ *   - Applications that call tzalloc(3) with untrusted timezone names
+ *
+ * TZif format bugs that this harness can find:
+ *   - Integer overflow in detzcode()/detzcode64() result usage
+ *   - OOB read in ttis[], leaps[], chars[] array accesses
+ *   - Sign extension issues in transition time handling
+ *   - Incorrect bounds checks on ttisstdcnt/ttisutcnt/leapcnt/timecnt/typecnt/charcnt
+ *   - Version-2/3 header parsing inconsistencies
+ *
+ * Build:
+ *   clang -fsanitize=fuzzer,address -DDONT_USE_TZDB fuzz/fuzz_tzif.c \
+ *         localtime.c asctime.c difftime.c strftime.c \
+ *         -o fuzz_tzif
+ *
+ * OSS-Fuzz:
+ *   $CC $CFLAGS $LIB_FUZZING_ENGINE fuzz/fuzz_tzif.c localtime.c \
+ *       asctime.c difftime.c strftime.c -o $OUT/fuzz_tzif
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+/*
+ * Write fuzz data to a temp file, set TZ to point to it,
+ * then call tzset() to trigger tzloadbody().
+ * This exercises the exact production code path.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    /* Write fuzz data to a temporary file */
+    char tmppath[] = "/tmp/fuzz_tz_XXXXXX";
+    int fd = mkstemp(tmppath);
+    if (fd < 0)
+        return 0;
+
+    if (write(fd, data, size) != (ssize_t)size) {
+        close(fd);
+        unlink(tmppath);
+        return 0;
+    }
+    close(fd);
+
+    /* Set TZ env var to point to our file (colon prefix = absolute path) */
+    char tz_env[256];
+    snprintf(tz_env, sizeof(tz_env), ":%s", tmppath);
+    setenv("TZ", tz_env, 1);
+
+    /*
+     * tzset() calls tzloadbody() which parses the TZif binary format.
+     * With ASan/MSan, any OOB read/write or use-after-free will be caught.
+     */
+    tzset();
+
+    /*
+     * Also call localtime() which uses the loaded timezone state
+     * to do transition lookups (exercises the binary search in transtime()).
+     */
+    time_t t = 0;
+    localtime(&t);
+    t = (time_t)1700000000; /* Nov 2023 */
+    localtime(&t);
+
+    unlink(tmppath);
+    return 0;
+}


### PR DESCRIPTION
## Summary

This PR adds a `fuzz/` directory with a [libFuzzer](https://llvm.org/docs/LibFuzzer.html) harness targeting `tzloadbody()` in `localtime.c` — the parser for TZif version 1/2/3 binary timezone data files.

## Motivation

`tzloadbody()` parses binary TZif files from disk when `tzset(3)` is called. This happens in every C/C++ program that uses timezone-aware functions. The input to this parser can be attacker-influenced in several realistic scenarios:

- **Container environments** where `/usr/share/zoneinfo` is a shared bind-mount that an attacker can write to
- **Applications calling `tzalloc()`** with user-controlled timezone names that map to files
- **The `TZ=:path` mechanism** — any program that reads TZ from an environment it doesn't fully control

A bug in the TZif parser (integer overflow in `detzcode` result usage, OOB array access on `ttis[]`/`leaps[]`/`chars[]`, or bounds check bypass on the header count fields) could cause memory corruption in every timezone-aware C program.

## How the Harness Works

The harness:
1. Writes fuzz data to a temporary file via `mkstemp()`
2. Sets `TZ=:<tmppath>` to point the runtime at that file
3. Calls `tzset()` — triggers `tzloadbody()` on the fuzz data
4. Calls `localtime()` with two different timestamps — exercises the binary search in `transtime()`
5. Cleans up the temp file

This exercises the exact same code path as production use.

## Coverage

With this harness + ASan/UBSan, the fuzzer covers:
- `detzcode()` / `detzcode64()` — big-endian 4/8-byte integer decoding
- Header field validation: `ttisstdcnt`, `ttisutcnt`, `leapcnt`, `timecnt`, `typecnt`, `charcnt`
- Array bounds for `ttis[]`, `leaps[]`, `chars[]`  
- TZif version 1 vs version 2/3 branching
- The POSIX TZ string parser called at the end of version-2/3 files

## Building

```bash
clang -fsanitize=fuzzer,address \
      fuzz/fuzz_tzif.c localtime.c asctime.c difftime.c strftime.c \
      -o fuzz_tzif

# Start with real timezone files as seed corpus
mkdir corpus/
cp /usr/share/zoneinfo/America/New_York corpus/ny
cp /usr/share/zoneinfo/UTC corpus/utc
./fuzz_tzif corpus/ -max_total_time=300
```